### PR TITLE
Avoid using loopback for server

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,8 @@ for i in $envVars; do
   perl -pi -e "s/$i/$val/g" /usr/local/lib/node_modules/bipio/config/config.json-dist
 done
 
+perl -pi -e "s/127\.0\.0\.1/0.0.0.0/g" /usr/local/lib/node_modules/bipio/config/config.json-dist
+
 mkdir -p /data/server_logs
 
 npm config set registry https://registry.npmjs.org


### PR DESCRIPTION
The docker on Ubuntu I tried cannot connect to a loopback exposed port. Maybe the default config has changed? This perl replace is not the nicest way, feel free to use another one. BTW: the search&replace in this file seems to do noting, there are no BIPIO_API_HOST placeholders in the distfile?
